### PR TITLE
Order feature

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :cart
+  # Création du panier si celui ci n'existe pas ou est vide
   def cart
     unless session[:cart]
       session[:cart] = []

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :cart
+  def cart
+    unless session[:cart]
+      session[:cart] = []
+    end
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,16 +2,20 @@ class OrdersController < ApplicationController
   def create
     product = Product.find(params[:product_id])
     order  = Order.create!(product: product, product_name: product.name, amount: product.price, state: 'pending', user: current_user)
+    items = session[:cart]
+    line_items = items.map do |item|
+      {
+        name: item["name"],
+        images: [item["photo_url"]],
+        amount: item["price_cents"],
+        currency: 'eur',
+        quantity: 1
+      }
+    end
 
     session = Stripe::Checkout::Session.create(
       payment_method_types: ['card'],
-      line_items: [{
-        name: product.name,
-        images: [product.photo_url],
-        amount: product.price_cents,
-        currency: 'eur',
-        quantity: 1
-      }],
+      line_items: line_items,
       success_url: order_url(order),
       cancel_url: order_url(order)
     )

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,6 +3,9 @@ class OrdersController < ApplicationController
     product = Product.find(params[:product_id])
     order  = Order.create!(product: product, product_name: product.name, amount: product.price, state: 'pending', user: current_user)
     items = session[:cart]
+    items.each do |element|
+      Item.create!(product_id: element["id"], order_id: order.id)
+    end
     line_items = items.map do |item|
       {
         name: item["name"],

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,21 +1,16 @@
 class OrdersController < ApplicationController
   def create
+    # Lignes 4 & 5 servent pour la partie active admin pour l'instant, à modifier plus tard
     product = Product.find(params[:product_id])
     order  = Order.create!(product: product, product_name: product.name, amount: product.price, state: 'pending', user: current_user)
-    items = session[:cart]
-    items.each do |element|
-      Item.create!(product_id: element["id"], order_id: order.id)
-    end
-    line_items = items.map do |item|
-      {
-        name: item["name"],
-        images: [item["photo_url"]],
-        amount: item["price_cents"],
-        currency: 'eur',
-        quantity: 1
-      }
-    end
 
+    items = session[:cart]
+
+    # Création des modèles Items pour chaque produit dans la commande, et récupération des infos pour la variable line_items
+    create_items_objects(items, order)
+    line_items = set_line_items(items)
+
+    # Lancement de la phase de paiement Stripe
     session = Stripe::Checkout::Session.create(
       payment_method_types: ['card'],
       line_items: line_items,
@@ -31,4 +26,36 @@ class OrdersController < ApplicationController
     @order = current_user.orders.find(params[:id])
   end
 
+  private
+
+  def create_items_objects(items, order)
+    items.each do |element|
+      Item.create!(product_id: element["id"], order_id: order.id)
+    end
+  end
+
+  def set_line_items(items)
+    # Si le cart n'est pas vide, on rempli line_items avec ses infos
+    unless items.empty?
+      items.map do |item|
+        {
+          name: item["name"],
+          images: [item["photo_url"]],
+          amount: item["price_cents"],
+          currency: 'eur',
+          quantity: 1
+        }
+      end
+      # s'il est vide, on rempli line_items avec les infos du produit de la page sur laquelle on a appuyé sur "purchase"
+    else
+      product = Product.find(params[:product_id])
+      [{
+        name: product.name,
+        images: [product.photo_url],
+        amount: product.price_cents,
+        currency: 'eur',
+        quantity: 1
+      }]
+    end
+  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -10,6 +10,7 @@ class ProductsController < ApplicationController
     @session = session[:cart]
   end
 
+  # Ajout d'un produit dans le panier
   def add_to_cart
     @product = Product.find(params[:id])
     session[:cart] << @product

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,11 +1,18 @@
 class ProductsController < ApplicationController
   skip_before_action :authenticate_user!
 
-def index
-  @products = Product.all
-end
+  def index
+    @products = Product.all
+  end
 
-def show
-  @product = Product.find(params[:id])
-end
+  def show
+    @product = Product.find(params[:id])
+    @session = session[:cart]
+  end
+
+  def add_to_cart
+    @product = Product.find(params[:id])
+    session[:cart] << @product
+    redirect_to products_path
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,4 @@
+class Item < ApplicationRecord
+  belongs_to :order
+  belongs_to :product
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :user
   belongs_to :product
+  has_many :items
+  has_many :products, through: :items
   monetize :amount_cents
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,6 @@
 class Product < ApplicationRecord
+  has_many :items, dependent: :destroy
+  has_many :orders
   belongs_to :shop_category
   belongs_to :artist
   monetize :price_cents

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -3,6 +3,7 @@
     <div class="col-sm-12 col-md-6">
       <%= image_tag(@product.photo_url, width: '100%') %>
     </div>
+    <p><%= @session %></p>
     <div class="col-sm-12 col-md-6">
       <h1><%= @product.name %></h1>
       <p>Some awesome description of our amazing product.</p>
@@ -10,6 +11,7 @@
       <%= form_tag orders_path do %>
         <%= hidden_field_tag 'product_id', @product.id %>
         <%= submit_tag 'Purchase', class: 'btn btn-primary' %>
+        <%= link_to "Add To Cart", add_to_cart_product_path(@product), class: 'btn btn-primary'  %>
       <% end %>
     </div>
   </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -3,7 +3,7 @@
     <div class="col-sm-12 col-md-6">
       <%= image_tag(@product.photo_url, width: '100%') %>
     </div>
-    <p><%= @session %></p>
+    <!-- <p><%= @session %></p> -->
     <div class="col-sm-12 col-md-6">
       <h1><%= @product.name %></h1>
       <p>Some awesome description of our amazing product.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
   resources :events, only: [:index, :show] do
   end
   resources :products, only: [:index, :show] do
+    member do
+      get :add_to_cart
+    end
   end
   resources :orders, only: [:show, :create] do
     resources :payments, only: :new

--- a/db/migrate/20200622085631_create_items.rb
+++ b/db/migrate/20200622085631_create_items.rb
@@ -1,0 +1,10 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.references :order, null: false, foreign_key: true
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_115234) do
+ActiveRecord::Schema.define(version: 2020_06_22_085631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,15 @@ ActiveRecord::Schema.define(version: 2020_06_17_115234) do
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 
+  create_table "items", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.bigint "product_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_items_on_order_id"
+    t.index ["product_id"], name: "index_items_on_product_id"
+  end
+
   create_table "orders", force: :cascade do |t|
     t.string "state"
     t.string "product_name"
@@ -142,6 +151,8 @@ ActiveRecord::Schema.define(version: 2020_06_17_115234) do
   add_foreign_key "artists", "users"
   add_foreign_key "events", "artists"
   add_foreign_key "events", "users"
+  add_foreign_key "items", "orders"
+  add_foreign_key "items", "products"
   add_foreign_key "orders", "products"
   add_foreign_key "orders", "users"
   add_foreign_key "products", "artists"

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# Order feature
## Ajouts
### Création de la table "Items"
- Table jointure entre **Orders** et **Products** qui sert à décentraliser les produits achetés dans une commande de notre table orders, et donc résout le souci d'avoir plusieurs produits dans une commande.

`Order.products` _Pour avoir accès à tous les produits d'une commande_ (via table de jointure)
ℹ️ _ça n'impacte que les nouvelles commandes_

### Méthodes de création d'Items et modification des arguments à passer à Stripe
ℹ️ Pour que Stripe facture plusieurs produits, il suffit de lui donner plusieurs hashs dans le paramètre "line_items" de stripe checkout session...

- **Méthode create_items_objects** : sert à créer un objet Item pour chaque produit d'une commande.

-**Méthode set_line_items** : sert à injecter les bons paramètres dans la variable line_items selon si le cart est vide ou s'il contient déjà des objets
Cette méthode pourra peut-être sauter à l'avenir selon l'utilisation que l'on aura du bouton purchase et add to cart, à voir.