### PR TITLE
Signup design

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,7 +3,7 @@
   <h2 class="text-center text-3xl text-gray-700 font-bold mb-4">Inscription</h2>
 
   <!-- registration card -->
-  <div class="bg-white shadow-md rounder w-full max-w-lg mx-auto mb-2">
+  <div class="bg-white shadow-md rounder w-full max-w-lg mx-auto mb-10">
     <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= f.error_notification %>
 
@@ -36,7 +36,6 @@
           <%= f.button :submit, "Créer un compte", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mt-4" %>
         </div>
       </div>
-
     <% end %>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,25 +1,44 @@
-<h2>Sign up</h2>
+<!-- container -->
+<div>
+  <h2 class="text-center text-3xl text-gray-700 font-bold mb-4">Inscription</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
+  <!-- registration card -->
+  <div class="bg-white shadow-md rounder w-full max-w-lg mx-auto mb-2">
+    <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
-                required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
+      <div class="form-inputs px-8 pt-6 pb-8 mb-4">
+        <%= f.input :email,
+                    # required: true,
+                    autofocus: true,
+                    placeholder: "exemple@exmaple.fr",
+                    input_html: { autocomplete: "email" },
+                    input_html: { class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline mb-4" },
+                    label_html: { class: "block uppercase text-gray-700 text-sm font-bold my-2" } %>
+        <%= f.input :password,
+                    # required: true,
+                    label: "Mot de passe",
+                    placeholder: "**********",
+                    hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                    input_html: { autocomplete: "new-password" },
+                    input_html: { class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline mb-4" },
+                    label_html: { class: "block uppercase text-gray-700 text-sm font-bold my-2" } %>
+        <%= f.input :password_confirmation,
+                    # required: true,
+                    label: "Confirmation du mot de passe",
+                    placeholder: "**********",
+                    input_html: { autocomplete: "new-password" },
+                    input_html: { class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline mb-4" },
+                    label_html: { class: "block uppercase text-gray-700 text-sm font-bold my-2" } %>
+
+
+        <div class="form-actions">
+          <%= f.button :submit, "Créer un compte", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mt-4" %>
+        </div>
+      </div>
+
+    <% end %>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, "Créer un compte" %>
-  </div>
-<% end %>
+</div>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <!-- container -->
 <div>
-  <h2 class="text-center text-3xl text-gray-700 font-bold mb-4">Inscription</h2>
+  <h2 class="text-center text-3xl text-white bg-primary font-bold mx-auto mb-4 p-1" style="width: fit-content">Inscription</h2>
 
   <!-- registration card -->
   <div class="bg-white shadow-md rounder w-full max-w-lg mx-auto mb-10">


### PR DESCRIPTION
# Signup design
## Modifs
### Changement du design de la page signup pour qu'il soit identique à celui de sign-in
ℹ️ Je vais faire une autre PR pour retoucher un chouya ce que tu avais fait mathieu, pour le sign-in histoire que le titre par exemple, soit raccord avec celui de sign-up, qui du coup est un poil plus homogène par rapport au design du site. Changer les placeholders en français etc. ℹ️ 

**Rien de spécial à dire concernant cette PR, voir la capture d'écran :**
<img width="919" alt="Capture d’écran 2020-07-15 à 11 20 08" src="https://user-images.githubusercontent.com/58357600/87527963-2b750880-c68d-11ea-999a-50ea5be0daf4.png">
